### PR TITLE
Magnetometer calibration

### DIFF
--- a/rocko_env/rocko_env/hardware/sensors/icm20948/ICM20948.py
+++ b/rocko_env/rocko_env/hardware/sensors/icm20948/ICM20948.py
@@ -66,10 +66,10 @@ class ICM20948(Node):
         m = np.array(self.icm.magnetic)
     
         # Apply calibration to m
-        for i in range(3):
-            m[i] = m[i] + self.calibration_results[i]
+        # for i in range(3):
+        #     m[i] = m[i] + self.calibration_results[i]
 
-        current_q = self.madgwick.updateIMU(q=self.prev_q, gyr=g, acc=a, mag=m)
+        current_q = self.madgwick.updateIMU(q=self.prev_q, gyr=g, acc=a)
         self.prev_q = current_q
         angles = np.degrees(Quaternion(current_q).to_angles())
 

--- a/rocko_env/rocko_env/hardware/sensors/icm20948/ICM20948.py
+++ b/rocko_env/rocko_env/hardware/sensors/icm20948/ICM20948.py
@@ -69,7 +69,7 @@ class ICM20948(Node):
         for i in range(3):
             m[i] = m[i] + self.calibration_results[i]
 
-        current_q = self.madgwick.updateMARG(q=self.prev_q, gyr=g, acc=a, mag=m)
+        current_q = self.madgwick.updateIMU(q=self.prev_q, gyr=g, acc=a, mag=m)
         self.prev_q = current_q
         angles = np.degrees(Quaternion(current_q).to_angles())
 

--- a/rocko_env/rocko_env/hardware/sensors/icm20948/ICM20948.py
+++ b/rocko_env/rocko_env/hardware/sensors/icm20948/ICM20948.py
@@ -28,17 +28,15 @@ class ICM20948(Node):
         num_calib_samples = 100
         gyr_arr = np.zeros((num_calib_samples, 3))
         acc_arr = np.zeros((num_calib_samples, 3))
-        mag_arr = np.zeros((num_calib_samples, 3))
         for i in range(0, num_calib_samples):
             # Add data to sample arrays
             gyr_arr[i] = self.icm.gyro
             acc_arr[i] = self.icm.acceleration
-            mag_arr[i] = self.icm.magnetic
             # Wait for 10ms for new data to be gathered
             sleep(0.01)
 
         # Calculate median
-        self.madgwick = Madgwick(gyr_arr, acc_arr, mag_arr)
+        self.madgwick = Madgwick(gyr_arr, acc_arr)
         self.prev_q = np.median(self.madgwick.Q, axis=0)
 
         # Check filesystem for magnetometer calibration data
@@ -63,11 +61,6 @@ class ICM20948(Node):
     def imu_callback(self, request, response):
         g = np.array(self.icm.gyro)
         a = np.array(self.icm.acceleration)
-        m = np.array(self.icm.magnetic)
-    
-        # Apply calibration to m
-        # for i in range(3):
-        #     m[i] = m[i] + self.calibration_results[i]
 
         current_q = self.madgwick.updateIMU(q=self.prev_q, gyr=g, acc=a)
         self.prev_q = current_q

--- a/rocko_env/rocko_env/hardware/sensors/icm20948/ICM20948.py
+++ b/rocko_env/rocko_env/hardware/sensors/icm20948/ICM20948.py
@@ -51,7 +51,7 @@ class ICM20948(Node):
                 for i in file:
                     self.calibration_results.append(i)
         except:
-            self.get_logger().warn('No magnetometer calibration data found, proceeding anyway.')
+            # self.get_logger().warn('No magnetometer calibration data found, proceeding anyway.')
             for i in range(3):
                 self.calibration_results.append(0)
 
@@ -61,21 +61,22 @@ class ICM20948(Node):
 
 
     def imu_callback(self, request, response):
-        g = np.array([self.icm.gyro])
-        a = np.array([self.icm.acceleration])
-        m = np.array([self.icm.magnetic])
-
+        g = np.array(self.icm.gyro)
+        a = np.array(self.icm.acceleration)
+        m = np.array(self.icm.magnetic)
+    
         # Apply calibration to m
-        for i in range(3):
-            m[i] = m[i] + self.calibration_results[i]
+        # for i in range(3):
+        #     m[i] = m[i] + self.calibration_results[i]
 
-        current_q = self.madgwick.updateIMU(self.prev_q, g, a, 0.01)
-        angles = Quaternion(current_q).to_angles()
+        current_q = self.madgwick.updateIMU(q=self.prev_q, gyr=g, acc=a)
+        self.prev_q = current_q
+        angles = np.degrees(Quaternion(current_q).to_angles())
 
         # Prepare data for sending
-        response.yaw = self.angles[0]
-        response.roll = self.angles[1]
-        response.pitch = self.angles[2]
+        response.yaw = angles[0]
+        response.roll = angles[1]
+        response.pitch = angles[2]
 
         return response
 

--- a/rocko_env/rocko_env/hardware/sensors/icm20948/ICM20948.py
+++ b/rocko_env/rocko_env/hardware/sensors/icm20948/ICM20948.py
@@ -69,7 +69,7 @@ class ICM20948(Node):
         for i in range(3):
             m[i] = m[i] + self.calibration_results[i]
 
-        current_q = self.madgwick.updateIMU(q=self.prev_q, gyr=g, acc=a, mag=m)
+        current_q = self.madgwick.updateMARG(q=self.prev_q, gyr=g, acc=a, mag=m)
         self.prev_q = current_q
         angles = np.degrees(Quaternion(current_q).to_angles())
 

--- a/rocko_env/rocko_env/hardware/sensors/icm20948/ICM20948.py
+++ b/rocko_env/rocko_env/hardware/sensors/icm20948/ICM20948.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+import os
+
 import rclpy
 from rclpy.node import Node
 import board
@@ -38,6 +40,20 @@ class ICM20948(Node):
         # Calculate median
         self.initial_q = np.median(Complementary(gyr_arr, acc_arr, mag_arr).Q, axis=0)
 
+        # Check filesystem for magnetometer calibration data
+        path = os.path.join('calibration', 'hard_offset')
+        self.calibration_results = []
+        try:
+            # If cal data is there, we will interpolate it for offset
+            # Extract calibration values from cal file (newline deliniated)
+            with open(path) as file:
+                for i in file:
+                    self.calibration_results.append(i)
+        except:
+            self.get_logger().warn('No magnetometer calibration data found, proceeding anyway.')
+            for i in range(3):
+                self.calibration_results.append(0)
+
         # Create a new service called /icm20948_data for posting IMU positional data
         super().__init__('icm20948_node')
         self.srv = self.create_service(Icm20948Data, 'icm20948_data', self.imu_callback)
@@ -47,6 +63,11 @@ class ICM20948(Node):
         g = np.array([self.icm.gyro])
         a = np.array([self.icm.acceleration])
         m = np.array([self.icm.magnetic])
+
+        # Apply calibration to m
+        for i in range(3):
+            m[i] = m[i] + self.calibration_results[i]
+
         current_q = Complementary(g, a, m).Q[0]
         diff = np.subtract(current_q, self.initial_q)
         angles = Quaternion(diff).to_angles()

--- a/rocko_env/rocko_env/hardware/sensors/icm20948/ICM20948.py
+++ b/rocko_env/rocko_env/hardware/sensors/icm20948/ICM20948.py
@@ -66,10 +66,10 @@ class ICM20948(Node):
         m = np.array(self.icm.magnetic)
     
         # Apply calibration to m
-        # for i in range(3):
-        #     m[i] = m[i] + self.calibration_results[i]
+        for i in range(3):
+            m[i] = m[i] + self.calibration_results[i]
 
-        current_q = self.madgwick.updateIMU(q=self.prev_q, gyr=g, acc=a)
+        current_q = self.madgwick.updateIMU(q=self.prev_q, gyr=g, acc=a, mag=m)
         self.prev_q = current_q
         angles = np.degrees(Quaternion(current_q).to_angles())
 

--- a/rocko_env/rocko_env/hardware/sensors/icm20948/calibration/calibrate_magnetometer.py
+++ b/rocko_env/rocko_env/hardware/sensors/icm20948/calibration/calibrate_magnetometer.py
@@ -1,0 +1,47 @@
+'''
+Custom script meant to be run once to generate magnetometer hard offset data.
+Should be carried out with all hardware installed on the robot sans the legs
+for convenience. 
+
+Outputs "hard_offset" within the same directory.
+
+Adapted from the following jupyter notebook: https://github.com/adafruit/Adafruit_SensorLab/blob/master/notebooks/Mag_Gyro_Calibration.ipynb 
+'''
+import board
+import numpy as np
+import adafruit_icm20x
+from time import sleep
+
+def __init__(self, memory=None):
+        i2c = board.I2C()   # uses board.SCL and board.SDA
+        self.icm = adafruit_icm20x.ICM20948(i2c)
+        if memory == None:
+            self.memory = 2500
+        else:
+            self.memory = memory
+        self.mag_arr = np.zeros((self.memory, 3))
+
+def capture_dataset(self):
+    self.get_logger().info('Starting magnetometer capture.')   
+    for i in range(0, self.memory):
+        # Add data to sample arrays
+        self.mag_arr[i] = self.icm.magnetic
+        # Wait for 10ms for new data to be gathered
+        sleep(0.01) 
+    self.get_logger().info('Magnetometer capture done.')   
+
+def calibrate_dataset(self):
+    min_x = min(t[0] for t in self.mag_arr)
+    min_y = min(t[1] for t in self.mag_arr)
+    min_z = min(t[2] for t in self.mag_arr)
+
+    max_x = max(t[0] for t in self.mag_arr)
+    max_y = max(t[1] for t in self.mag_arr)
+    max_z = max(t[2] for t in self.mag_arr)
+
+    mag_calibration = [ (max_x + min_x) / 2, (max_y + min_y) / 2, (max_z + min_z) / 2]
+
+    # write mag_calibration to file
+    with open('hard_offset', 'w') as f:
+          for i in range(3):
+            f.write(f"{mag_calibration[i]}\n")

--- a/rocko_env/rocko_env/hardware/sensors/icm20948/calibration/calibrate_magnetometer.py
+++ b/rocko_env/rocko_env/hardware/sensors/icm20948/calibration/calibrate_magnetometer.py
@@ -3,8 +3,6 @@ Custom script meant to be run once to generate magnetometer hard offset data.
 Should be carried out with all hardware installed on the robot sans the legs
 for convenience. 
 
-Outputs "hard_offset" within the same directory.
-
 Adapted from the following jupyter notebook: https://github.com/adafruit/Adafruit_SensorLab/blob/master/notebooks/Mag_Gyro_Calibration.ipynb 
 '''
 import board
@@ -22,13 +20,13 @@ def __init__(self, memory=None):
         self.mag_arr = np.zeros((self.memory, 3))
 
 def capture_dataset(self):
-    self.get_logger().info('Starting magnetometer capture.')   
+    print('Starting magnetometer capture.')   
     for i in range(0, self.memory):
         # Add data to sample arrays
         self.mag_arr[i] = self.icm.magnetic
         # Wait for 10ms for new data to be gathered
         sleep(0.01) 
-    self.get_logger().info('Magnetometer capture done.')   
+    print('Magnetometer capture done.')   
 
 def calibrate_dataset(self):
     min_x = min(t[0] for t in self.mag_arr)

--- a/rocko_env/rocko_env/hardware/sensors/icm20948/calibration/calibrate_magnetometer.py
+++ b/rocko_env/rocko_env/hardware/sensors/icm20948/calibration/calibrate_magnetometer.py
@@ -10,36 +10,37 @@ import numpy as np
 import adafruit_icm20x
 from time import sleep
 
-def __init__(self, memory=None):
-        i2c = board.I2C()   # uses board.SCL and board.SDA
-        self.icm = adafruit_icm20x.ICM20948(i2c)
-        if memory == None:
-            self.memory = 2500
-        else:
-            self.memory = memory
-        self.mag_arr = np.zeros((self.memory, 3))
+class MagCalibrator:
+    def __init__(self, memory=None):
+            i2c = board.I2C()   # uses board.SCL and board.SDA
+            self.icm = adafruit_icm20x.ICM20948(i2c)
+            if memory == None:
+                self.memory = 2500
+            else:
+                self.memory = memory
+            self.mag_arr = np.zeros((self.memory, 3))
 
-def capture_dataset(self):
-    print('Starting magnetometer capture.')   
-    for i in range(0, self.memory):
-        # Add data to sample arrays
-        self.mag_arr[i] = self.icm.magnetic
-        # Wait for 10ms for new data to be gathered
-        sleep(0.01) 
-    print('Magnetometer capture done.')   
+    def capture_dataset(self):
+        print('Starting magnetometer capture.')   
+        for i in range(0, self.memory):
+            # Add data to sample arrays
+            self.mag_arr[i] = self.icm.magnetic
+            # Wait for 10ms for new data to be gathered
+            sleep(0.01) 
+        print('Magnetometer capture done.')   
 
-def calibrate_dataset(self):
-    min_x = min(t[0] for t in self.mag_arr)
-    min_y = min(t[1] for t in self.mag_arr)
-    min_z = min(t[2] for t in self.mag_arr)
+    def calibrate_dataset(self):
+        min_x = min(t[0] for t in self.mag_arr)
+        min_y = min(t[1] for t in self.mag_arr)
+        min_z = min(t[2] for t in self.mag_arr)
 
-    max_x = max(t[0] for t in self.mag_arr)
-    max_y = max(t[1] for t in self.mag_arr)
-    max_z = max(t[2] for t in self.mag_arr)
+        max_x = max(t[0] for t in self.mag_arr)
+        max_y = max(t[1] for t in self.mag_arr)
+        max_z = max(t[2] for t in self.mag_arr)
 
-    mag_calibration = [ (max_x + min_x) / 2, (max_y + min_y) / 2, (max_z + min_z) / 2]
+        mag_calibration = [ (max_x + min_x) / 2, (max_y + min_y) / 2, (max_z + min_z) / 2]
 
-    # write mag_calibration to file
-    with open('hard_offset', 'w') as f:
-          for i in range(3):
-            f.write(f"{mag_calibration[i]}\n")
+        # write mag_calibration to file
+        with open('hard_offset', 'w') as f:
+            for i in range(3):
+                f.write(f"{mag_calibration[i]}\n")

--- a/rocko_env/rocko_env/hardware/sensors/icm20948/calibration/run_calibration.py
+++ b/rocko_env/rocko_env/hardware/sensors/icm20948/calibration/run_calibration.py
@@ -1,5 +1,5 @@
-import calibrate_magnetometer
+from calibrate_magnetometer import MagCalibrator
 
 input('Press any key to begin calibration.')
-calibrate_magnetometer.capture_dataset()
-calibrate_magnetometer.calibrate_dataset()
+MagCalibrator.capture_dataset()
+MagCalibrator.calibrate_dataset()

--- a/rocko_env/rocko_env/hardware/sensors/icm20948/calibration/run_calibration.py
+++ b/rocko_env/rocko_env/hardware/sensors/icm20948/calibration/run_calibration.py
@@ -1,5 +1,6 @@
 from calibrate_magnetometer import MagCalibrator
 
 input('Press any key to begin calibration.')
-MagCalibrator.capture_dataset()
-MagCalibrator.calibrate_dataset()
+
+MagCalibrator().capture_dataset()
+MagCalibrator().calibrate_dataset()

--- a/rocko_env/rocko_env/hardware/sensors/icm20948/calibration/run_calibration.py
+++ b/rocko_env/rocko_env/hardware/sensors/icm20948/calibration/run_calibration.py
@@ -1,0 +1,5 @@
+import calibrate_magnetometer
+
+input('Press any key to begin calibration.')
+calibrate_magnetometer.capture_dataset()
+calibrate_magnetometer.calibrate_dataset()


### PR DESCRIPTION
Let's not merge this yet. A couple of things:

1. in ICM20948.py we initialize `angles` as `Quaternion(diff).to_angles()` but do not use this variable later. Instead we reference array `self.angles`, which doesn't appear as defined in `__init__`. Intended or not?
2. Just want to sanity check that it's OK to perform the hard offset logic before the sensor fusion. I'm not sure how else you'd do it, but regardless.
3. Do we need to remove the magnetometer averaging logic in self.initial_q? I think we might, since we'd already be providing a correction with the magnetometer calibration.